### PR TITLE
Change model_name to model_class

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -133,8 +133,8 @@ title: 'Neo4j.rb: (ruby)-[:LOVES]-(neo4j)'
                 property :name
                 property :age, type: Integer
 
-                has_many :out, :friends, type: :friends_with, model_name: 'User'
-                has_one :in,   :github_profile, type: :linked_to  # model_name: 'GithubProfile' assumed
+                has_many :out, :friends, type: :friends_with, model_class: 'User'
+                has_one :in,   :github_profile, type: :linked_to  # model_class: 'GithubProfile' assumed
               end
             ```
 


### PR DESCRIPTION
I believe this is simply outdated since the has_n association will throw `Unknown option(s) specified: model_name (Class#story) (ArgumentError)`