### PR TITLE
Add missing require for rails

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -181,6 +181,8 @@ title: 'Neo4j.rb: (ruby)-[:LOVES]-(neo4j)'
           In your `config/application.rb`
 
           ```ruby
+            require 'neo4j/railtie'
+
             config.neo4j.session_type = :server_db
             config.neo4j.session_path = ENV['NEO4J_URL'] || 'http://localhost:7475'
           ```


### PR DESCRIPTION
On the http://neo4jrb.io/ page, the Ruby on Rails instructions don't
note the necessary railtie/require

Related to: https://github.com/neo4jrb/neo4j/issues/447

The read the docs site includes the require, but the neo4jrb.io site is
the first place I navigated to when looking for basic
ruby/rails/neo4j configuration/setup